### PR TITLE
nominations: add campaigns

### DIFF
--- a/nominations/src/ext.rs
+++ b/nominations/src/ext.rs
@@ -3,7 +3,7 @@ use near_sdk::{ext_contract, AccountId};
 
 #[ext_contract(ext_self)]
 pub trait ExtSelf {
-    fn on_nominate_verified(&mut self, nominator: AccountId, nominee: AccountId);
+    fn on_nominate_verified(&mut self, campaign: u32, nominator: AccountId, nominee: AccountId);
 }
 
 #[ext_contract(ext_sbtreg)]

--- a/nominations/src/lib.rs
+++ b/nominations/src/lib.rs
@@ -1,5 +1,5 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::collections::{LookupMap, UnorderedSet};
+use near_sdk::collections::{LookupMap, LookupSet};
 use near_sdk::{env, near_bindgen, require, AccountId, PanicOnDefault, PromiseResult};
 
 mod constants;
@@ -20,7 +20,7 @@ pub struct Contract {
     /// IAH class ID used for Facetech verification
     pub iah_class_id: u64,
     /// map of nominations (nominator -> nominee)
-    pub nominations: UnorderedSet<NominationKey>,
+    pub nominations: LookupSet<NominationKey>,
     /// map of `(campaign, nominee)` => number of received nominations
     pub nominations_sum: LookupMap<(u32, AccountId), u64>,
     pub campaigns: LookupMap<u32, Campaign>,
@@ -34,7 +34,7 @@ impl Contract {
             sbt_registry,
             iah_issuer,
             iah_class_id,
-            nominations: UnorderedSet::new(StorageKey::Nominations),
+            nominations: LookupSet::new(StorageKey::Nominations),
             nominations_sum: LookupMap::new(StorageKey::NominationsPerUser),
             campaigns: LookupMap::new(StorageKey::Campaigns),
         }

--- a/nominations/src/storage.rs
+++ b/nominations/src/storage.rs
@@ -1,15 +1,39 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::{AccountId, BorshStorageKey};
+use near_sdk::{env, require, AccountId, BorshStorageKey};
 
 /// Helper structure for keys of the persistent collections.
 #[derive(BorshSerialize, BorshStorageKey)]
 pub enum StorageKey {
     Nominations,
     NominationsPerUser,
+    Campaigns,
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct NominationKey {
+    pub campaign: u32,
     pub nominator: AccountId,
     pub nominee: AccountId,
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+pub struct Campaign {
+    pub name: String,
+    pub link: String,
+    /// start and end time for the nominations
+    pub start_time: u64,
+    pub end_time: u64,
+}
+
+impl Campaign {
+    pub fn assert_active(self) {
+        let current_timestamp = env::block_timestamp();
+        require!(
+            current_timestamp <= self.end_time && current_timestamp >= self.start_time,
+            format!(
+                "Campaign not active. start_time: {}, end_time: {}",
+                self.start_time, self.end_time
+            )
+        );
+    }
 }


### PR DESCRIPTION
During the meeting last week we discussed to add campaign / affair level.
This PR adds the campaign, and allows users to nominate per campaign.