### PR TITLE
add revoke_vote method

### DIFF
--- a/elections/README.md
+++ b/elections/README.md
@@ -46,6 +46,9 @@ near view $CTR proposals '{"prop_id": 2}'
 # vote
 
 near call $CTR vote '{"prop_id": 1, "vote": ["candidate1.testnet", "candidate3.testnet"]}' --gas 70000000000000 --deposit 0.002 --accountId me.testnet
+
+# revoke vote (authority only)
+near call $CTR revoke_vote '{"prop_id": 1, "token_id": 1}'
 ```
 
 ## Deployed Contracts

--- a/elections/src/storage.rs
+++ b/elections/src/storage.rs
@@ -6,4 +6,5 @@ use near_sdk::BorshStorageKey;
 pub enum StorageKey {
     Proposals,
     ProposalVoters(u32),
+    VotersCandidates(u32),
 }


### PR DESCRIPTION
+ add `revoke_vote` method to revoke votes from blacklisted accounts 
+ unit tests
+ update `README`

This PR creates a problem with a migration. We are adding a new field to the contract that is needed to revoke the votes, however we do not have the "old" data in the contract to migrate it properly. We only have a testing election contract deployed so I suggest to erase the current state and redeploy it. 