### PR TITLE
ci: use unit-tests and add registry.wasm check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,4 +44,5 @@ jobs:
         run: cargo clippy
       - name: Run tests
         if: env.GIT_DIFF
-        run: cargo test --verbose
+        # TODO: switch to all tests once we find efficient way how to link registry contract
+        run: make test-unit

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,8 @@ lint-md:
 	markdownlint-cli2-config .markdownlint.json  **/*.md
 
 test:
+	@[ -f "res/registry.wasm" ] || (echo "res/registry.wasm is required to run integration tests. Link it to the registry contract from the i-am-human repository" && exit 1)
 	@cargo test
+
+test-unit:
+	@cargo test --lib

--- a/Makefile-common.mk
+++ b/Makefile-common.mk
@@ -26,6 +26,7 @@ lint-fix:
 
 test:
 # to test specific test run: cargo test <test name>
+	@[ -f "../res/registry.wasm" ] || (echo "res/registry.wasm is required to run integration tests. Link it to the registry contract from the i-am-human repository" && exit 1)
 	@cargo test
 
 test-unit-debug:


### PR DESCRIPTION
* fixes CI by running unit tests, rather than integration tests (we will add registry.wasm later using github releases).
* updates Makefile to check if registry.wasm is present.