### PR TITLE
min_candidate_support

### DIFF
--- a/elections/README.md
+++ b/elections/README.md
@@ -13,6 +13,8 @@
   - `ref_link`: string (can't be empty) - a link to external resource with more details (eg near social post). Max length is 120 characters.
   - `quorum`: minimum amount of legit accounts to vote to legitimize the elections.
   - `seats`: max number of candidates to elect, also max number of credits each user has when casting a vote.
+  - `policy`: fair voting policy that must be accepted before voting on the proposal.
+  - `min_candidate_support`: minimum amount of votes a candidate needs to recive to be considered a winner.
 
 ## Flow
 
@@ -35,7 +37,7 @@ REGISTRY=registry-1.i-am-human.testnet
 # create proposal
 # note: start time, end time and cooldown must be in milliseconds
 
-near call $CTR create_proposal '{"start": 1686221747000, "end": 1686653747000, "cooldown": 604800000  "ref_link": "example.com", "quorum": 10, "candidates": ["candidate1.testnet", "candidate2.testnet", "candidate3.testnet", "candidate4.testnet"], "typ": "HouseOfMerit", "seats": 3, "policy": "f1c09f8686fe7d0d798517111a66675da0012d8ad1693a47e0e2a7d3ae1c69d4"}' --accountId $CTR
+near call $CTR create_proposal '{"start": 1686221747000, "end": 1686653747000, "cooldown": 604800000  "ref_link": "example.com", "quorum": 10, "candidates": ["candidate1.testnet", "candidate2.testnet", "candidate3.testnet", "candidate4.testnet"], "typ": "HouseOfMerit", "seats": 3, "policy": "f1c09f8686fe7d0d798517111a66675da0012d8ad1693a47e0e2a7d3ae1c69d4", "min_candidate_support": 5}' --accountId $CTR
 
 # fetch all proposal
 near view $CTR proposals ''

--- a/elections/src/lib.rs
+++ b/elections/src/lib.rs
@@ -69,6 +69,7 @@ impl Contract {
         seats: u16,
         #[allow(unused_mut)] mut candidates: Vec<AccountId>,
         policy: String,
+        min_candidate_support: u32,
     ) -> u32 {
         self.assert_admin();
         let min_start = env::block_timestamp_ms();
@@ -114,6 +115,7 @@ impl Contract {
             voters_num: 0,
             voters_candidates: LookupMap::new(StorageKey::VotersCandidates(self.prop_counter)),
             policy,
+            min_candidate_support,
         };
 
         self.proposals.insert(&self.prop_counter, &p);
@@ -279,6 +281,7 @@ mod unit_tests {
             2,
             vec![candidate(1), candidate(2), candidate(3)],
             policy1(),
+            2,
         )
     }
 
@@ -293,6 +296,7 @@ mod unit_tests {
             0,
             vec![],
             policy1(),
+            2,
         )
     }
 
@@ -360,6 +364,7 @@ mod unit_tests {
             2,
             vec![candidate(1)],
             policy1(),
+            2,
         );
     }
 
@@ -378,6 +383,7 @@ mod unit_tests {
             2,
             vec![candidate(1)],
             policy1(),
+            2,
         );
     }
 
@@ -396,6 +402,7 @@ mod unit_tests {
             2,
             vec![candidate(1)],
             policy1(),
+            2,
         );
     }
 
@@ -414,6 +421,7 @@ mod unit_tests {
             2,
             vec![candidate(1), candidate(1)],
             policy1(),
+            2,
         );
     }
 
@@ -432,6 +440,7 @@ mod unit_tests {
             0,
             vec![],
             policy1(),
+            2,
         );
         assert_eq!(n, 1);
 
@@ -446,6 +455,7 @@ mod unit_tests {
             2,
             vec![candidate(1)],
             policy1(),
+            2,
         );
     }
 
@@ -688,20 +698,6 @@ mod unit_tests {
         testing_env!(ctx);
 
         ctr.vote(prop_id, vec![candidate(1)]);
-    }
-
-    #[test]
-    fn accepted_policy_query() {
-        let (mut ctx, mut ctr) = setup(&admin());
-
-        let mut res = ctr.accepted_policy(admin());
-        assert!(res.is_none());
-        ctx.attached_deposit = ACCEPT_POLICY_COST;
-        testing_env!(ctx.clone());
-        ctr.accept_fair_voting_policy(policy1());
-        res = ctr.accepted_policy(admin());
-        assert!(res.is_some());
-        assert_eq!(res.unwrap(), policy1());
     }
 
     #[test]

--- a/elections/src/proposal.rs
+++ b/elections/src/proposal.rs
@@ -22,10 +22,11 @@ pub enum ProposalType {
 #[serde(crate = "near_sdk::serde")]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub enum ProposalStatus {
+    #[allow(non_camel_case_types)]
     NOT_STARTED,
     ONGOING,
     COOLDOWN,
-    ENDED
+    ENDED,
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
@@ -56,6 +57,8 @@ pub struct Proposal {
     pub voters_candidates: LookupMap<TokenId, Vec<usize>>,
     /// blake2s-256 hash of the Fair Voting Policy text.
     pub policy: [u8; 32],
+    /// min amount of votes for a candidate to be considered a "winner".
+    pub min_candidate_support: u32,
 }
 
 #[derive(Serialize)]
@@ -258,6 +261,7 @@ mod unit_tests {
             voters_num: 10,
             voters_candidates: LookupMap::new(StorageKey::VotersCandidates(1)),
             policy: policy1(),
+            min_candidate_support: 2,
         };
         assert_eq!(
             ProposalView {
@@ -299,6 +303,7 @@ mod unit_tests {
             voters_num: 3,
             voters_candidates: LookupMap::new(StorageKey::VotersCandidates(1)),
             policy: policy1(),
+            min_candidate_support: 2,
         };
         p.voters.insert(&1);
         p.voters.insert(&2);
@@ -340,6 +345,7 @@ mod unit_tests {
             voters_num: 1,
             voters_candidates: LookupMap::new(StorageKey::VotersCandidates(1)),
             policy: policy1(),
+            min_candidate_support: 2,
         };
         p.voters.insert(&1);
         p.voters_candidates.insert(&1, &vec![0, 1]);
@@ -371,6 +377,7 @@ mod unit_tests {
             voters_num: 1,
             voters_candidates: LookupMap::new(StorageKey::VotersCandidates(1)),
             policy: policy1(),
+            min_candidate_support: 2,
         };
         p.voters.insert(&1);
         p.voters_candidates.insert(&1, &vec![0, 1]);

--- a/elections/tests/iah.rs
+++ b/elections/tests/iah.rs
@@ -90,7 +90,7 @@ async fn init(
             "typ": ProposalType::HouseOfMerit, "start": start_time,
             "end": u64::MAX, "cooldown": 604800000, "ref_link": "test.io", "quorum": 10,
             "credits": 5, "seats": 1, "candidates": [john.id(), alice.id()],
-            "policy": policy1(),
+            "policy": policy1(), "min_candidate_support": 2,
         }))
         .max_gas()
         .transact();


### PR DESCRIPTION
+ add `min_candidate_support` to proposal
+ update unit tests
+ update integration tests
+ update readme
+ add ignore camel_case to the proposal status enum 
+ remove doubled unit tests 

SUGGESTIONS:

+ how about we call this field `winning_threshold` rather than `min_candidate_support` @robert-zaremba 