### PR TITLE
add disqualify_candidates

### DIFF
--- a/elections/src/lib.rs
+++ b/elections/src/lib.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 
 use events::{emit_bond, emit_revoke_vote, emit_vote};
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::collections::{LazyOption, LookupMap, UnorderedSet};
+use near_sdk::collections::{LazyOption, LookupMap};
 use near_sdk::json_types::U128;
 use near_sdk::{env, near_bindgen, require, AccountId, PanicOnDefault, Promise, PromiseOrValue};
 

--- a/elections/src/lib.rs
+++ b/elections/src/lib.rs
@@ -340,7 +340,7 @@ impl Contract {
         self.finish_time = finish_time;
     }
 
-    /// Allows admin disqualify candidates.
+    /// Allows admin to disqualify candidates.
     pub fn admin_disqualify_candidates(&mut self, candidates: Vec<AccountId>) {
         self.assert_admin();
         for c in candidates.iter() {
@@ -1453,9 +1453,9 @@ mod unit_tests {
             x => panic!("expected OK, got: {:?}", x),
         }
 
-        // Bond amount should be slashed
-        assert_eq!(ctr.bonded_amounts.get(&1), None);
-        assert_eq!(ctr.total_slashed, BOND_AMOUNT);
+        // Bond amount should not be slashed
+        assert_eq!(ctr.bonded_amounts.get(&1), Some(BOND_AMOUNT));
+        assert_eq!(ctr.total_slashed, 0);
 
         let p = ctr._proposal(1);
         assert_eq!(p.voters_num, 0, "vote should be revoked");

--- a/elections/src/lib.rs
+++ b/elections/src/lib.rs
@@ -449,7 +449,7 @@ impl Contract {
         );
     }
 
-    /// helper method to get the disqualified candidated indicies
+    /// helper method to get the disqualified candidate indices
     fn disqualifed_candidates_indices(&self, prop_id: u32) -> Vec<usize> {
         let proposal = self._proposal(prop_id);
 

--- a/elections/src/lib.rs
+++ b/elections/src/lib.rs
@@ -1772,7 +1772,10 @@ mod unit_tests {
         let (_, mut ctr) = setup(&admin());
         let disqualified_candidates = vec![candidate(1), candidate(2)];
         ctr.admin_disqualify_candidates(disqualified_candidates.clone());
-        assert_eq!(disqualified_candidates, ctr.disqualified_candidates());
+        let res = ctr.disqualified_candidates();
+        assert_eq!(res.len(), 2);
+        assert!(res.contains(&disqualified_candidates[0]));
+        assert!(res.contains(&disqualified_candidates[1]));
     }
 
     #[test]

--- a/elections/src/lib.rs
+++ b/elections/src/lib.rs
@@ -2,7 +2,7 @@ use std::cmp::max;
 
 use events::{emit_bond, emit_revoke_vote, emit_vote};
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::collections::LookupMap;
+use near_sdk::collections::{LookupMap, UnorderedSet};
 use near_sdk::json_types::U128;
 use near_sdk::{env, near_bindgen, require, AccountId, PanicOnDefault, Promise, PromiseOrValue};
 
@@ -10,6 +10,7 @@ mod constants;
 mod errors;
 mod events;
 mod ext;
+mod migrate;
 pub mod proposal;
 mod storage;
 mod view;
@@ -41,6 +42,9 @@ pub struct Contract {
     /// address which can pause the contract and make a new proposal. Should be a multisig / DAO;
     pub authority: AccountId,
     pub sbt_registry: AccountId,
+
+    /// list of disqualified candidates
+    pub disqualified_candidates: UnorderedSet<AccountId>,
 }
 
 #[near_bindgen]
@@ -66,6 +70,7 @@ impl Contract {
             prop_counter: 0,
             policy,
             finish_time,
+            disqualified_candidates: UnorderedSet::new(StorageKey::DisqualifiedCandidates),
         }
     }
 
@@ -300,7 +305,6 @@ impl Contract {
     ) -> Result<(), RevokeVoteError> {
         // check if the caller is the authority allowed to revoke votes
         self.assert_admin();
-        self.slash_bond(token_id);
         let mut p = self._proposal(prop_id);
         p.revoke_votes(token_id)?;
         self.proposals.insert(&prop_id, &p);
@@ -334,6 +338,14 @@ impl Contract {
             "new finish time must be after the existing one"
         );
         self.finish_time = finish_time;
+    }
+
+    /// Allows admin disqualify candidates.
+    pub fn admin_disqualify_candidates(&mut self, candidates: Vec<AccountId>) {
+        self.assert_admin();
+        for c in candidates.iter() {
+            self.disqualified_candidates.insert(c);
+        }
     }
 
     /*****************
@@ -436,6 +448,27 @@ impl Contract {
             "not an admin"
         );
     }
+
+    /// helper method to get the disqualified candidated indicies
+    fn disqualifed_candidates_indices(&self, prop_id: u32) -> Vec<usize> {
+        let proposal = self._proposal(prop_id);
+
+        // Use iterator methods to filter and map candidates to their indices
+        let disqualified_indices: Vec<usize> = proposal
+            .candidates
+            .iter()
+            .enumerate()
+            .filter_map(|(index, candidate)| {
+                if self.disqualified_candidates.contains(candidate) {
+                    Some(index)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        disqualified_indices
+    }
 }
 
 fn validate_setup_package(seats: u16, cs: &Vec<AccountId>) {
@@ -452,6 +485,8 @@ fn validate_setup_package(seats: u16, cs: &Vec<AccountId>) {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod unit_tests {
+    use std::ops::Mul;
+
     use near_sdk::{
         test_utils::{self, VMContextBuilder},
         testing_env, Gas, VMContext,
@@ -1715,5 +1750,41 @@ mod unit_tests {
         ctr.bond(alice(), mk_human_sbt(2), Value::String("".to_string()));
 
         assert_eq!(ctr.bonded_amounts.get(&2).unwrap(), 2 * BOND_AMOUNT);
+    }
+
+    #[test]
+    #[should_panic(expected = "not an admin")]
+    fn admin_disqualify_candidates_not_admin() {
+        let (_, mut ctr) = setup(&alice());
+        ctr.admin_disqualify_candidates(vec![candidate(1), candidate(2)])
+    }
+
+    #[test]
+    fn admin_disqualify_candidates() {
+        let (_, mut ctr) = setup(&admin());
+        let disqualified_candidates = vec![candidate(1), candidate(2)];
+        ctr.admin_disqualify_candidates(disqualified_candidates.clone());
+        assert_eq!(disqualified_candidates, ctr.disqualified_candidates());
+    }
+
+    #[test]
+    fn winners_by_proposal_disqualified_candidates() {
+        let (mut ctx, mut ctr) = setup(&admin());
+
+        // more seats than candidates
+        let prop_id = mock_proposal_and_votes(&mut ctx, &mut ctr, 5, 0);
+
+        // disqualify candidate(3)
+        ctr.admin_disqualify_candidates(vec![candidate(3), candidate(2)]);
+
+        // the method should return only the candiadtes that reach min_candidate support
+        // and are not disqualifed
+        ctx.block_timestamp = (START + 201) * MSECOND; // past cooldown
+        ctx.prepaid_gas = Gas::ONE_TERA.mul(10);
+        testing_env!(ctx.clone());
+        assert_eq!(
+            ctr.winners_by_proposal(prop_id),
+            vec![candidate(6), candidate(4), candidate(1), candidate(5)]
+        );
     }
 }

--- a/elections/src/migrate.rs
+++ b/elections/src/migrate.rs
@@ -22,7 +22,7 @@ impl Contract {
     pub fn migrate() -> Self {
         let old_state: OldState = env::state_read().expect("failed");
         // new field in the smart contract :
-        // + disqualified_candidates: Vec<AccountId>,
+        // + disqualified_candidates: LazyOption<HashSet<AccountId>>,
 
         Self {
             pause: old_state.pause,
@@ -35,7 +35,7 @@ impl Contract {
             finish_time: old_state.finish_time,
             authority: old_state.authority,
             sbt_registry: old_state.sbt_registry,
-            disqualified_candidates: UnorderedSet::new(StorageKey::DisqualifiedCandidates),
+            disqualified_candidates: LazyOption::new(StorageKey::DisqualifiedCandidates, None),
         }
     }
 }

--- a/elections/src/migrate.rs
+++ b/elections/src/migrate.rs
@@ -1,0 +1,41 @@
+use crate::*;
+
+#[derive(BorshDeserialize, PanicOnDefault)]
+pub struct OldState {
+    pub pause: bool,
+    pub prop_counter: u32,
+    pub proposals: LookupMap<u32, Proposal>,
+    pub policy: [u8; 32],
+    pub accepted_policy: LookupMap<AccountId, [u8; 32]>,
+    pub bonded_amounts: LookupMap<TokenId, u128>,
+    pub total_slashed: u128,
+    pub finish_time: u64,
+    pub authority: AccountId,
+    pub sbt_registry: AccountId,
+}
+
+#[near_bindgen]
+impl Contract {
+    #[private]
+    #[init(ignore_state)]
+    /* pub  */
+    pub fn migrate() -> Self {
+        let old_state: OldState = env::state_read().expect("failed");
+        // new field in the smart contract :
+        // + disqualified_candidates: Vec<AccountId>,
+
+        Self {
+            pause: old_state.pause,
+            prop_counter: old_state.prop_counter,
+            proposals: old_state.proposals,
+            policy: old_state.policy,
+            accepted_policy: old_state.accepted_policy,
+            bonded_amounts: old_state.bonded_amounts,
+            total_slashed: old_state.total_slashed,
+            finish_time: old_state.finish_time,
+            authority: old_state.authority,
+            sbt_registry: old_state.sbt_registry,
+            disqualified_candidates: UnorderedSet::new(StorageKey::DisqualifiedCandidates),
+        }
+    }
+}

--- a/elections/src/storage.rs
+++ b/elections/src/storage.rs
@@ -10,6 +10,7 @@ pub enum StorageKey {
     AcceptedPolicy,
     BondedAmount,
     UserSBT(u32),
+    DisqualifiedCandidates,
 }
 
 #[derive(PartialEq, Deserialize)]

--- a/elections/src/view.rs
+++ b/elections/src/view.rs
@@ -129,7 +129,7 @@ impl Contract {
     /// Returns the list of disqualified candidates
     pub fn disqualified_candidates(&self) -> Vec<AccountId> {
         let mut res = Vec::new();
-        for c in self.disqualified_candidates.iter() {
+        for c in self.disqualified_candidates.get().unwrap().iter() {
             res.push(c.clone());
         }
         res

--- a/elections/src/view.rs
+++ b/elections/src/view.rs
@@ -130,15 +130,10 @@ impl Contract {
 
     /// Returns the list of disqualified candidates
     pub fn disqualified_candidates(&self) -> Vec<AccountId> {
-        let mut res = Vec::new();
-        for c in self
-            .disqualified_candidates
+        self.disqualified_candidates
             .get()
             .unwrap_or(HashSet::new())
-            .iter()
-        {
-            res.push(c.clone());
-        }
-        res
+            .into_iter()
+            .collect()
     }
 }

--- a/elections/src/view.rs
+++ b/elections/src/view.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use near_sdk::{env, near_bindgen, AccountId, Balance};
 use uint::hex;
 
@@ -129,7 +131,12 @@ impl Contract {
     /// Returns the list of disqualified candidates
     pub fn disqualified_candidates(&self) -> Vec<AccountId> {
         let mut res = Vec::new();
-        for c in self.disqualified_candidates.get().unwrap().iter() {
+        for c in self
+            .disqualified_candidates
+            .get()
+            .unwrap_or(HashSet::new())
+            .iter()
+        {
             res.push(c.clone());
         }
         res

--- a/elections/src/view.rs
+++ b/elections/src/view.rs
@@ -79,7 +79,8 @@ impl Contract {
     }
 
     /// Returns a list of winners of the proposal if the elections is over and the quorum has been reached, otherwise returns empty list.
-    /// A candidate is considered the winner only if he reached the `min_candidate_support`.
+    /// A candidate is considered the winner only if he reached the `min_candidate_support`
+    /// and is not listed as disqualified.
     /// If the number of returned winners is smaller than the number of seats it means some of the candidates
     /// did not reach the required minimum support.
     /// If there is a tie break at the tail and it exceeds the number of seats, the accounts
@@ -94,19 +95,28 @@ impl Contract {
             return Vec::new();
         }
 
-        let mut indexed_results: Vec<(usize, u64)> =
-            proposal.result.into_iter().enumerate().collect();
+        let disqualified_candidates_indices = self.disqualifed_candidates_indices(prop_id);
+
+        // Filter and sort the candidates in one step
+        let mut indexed_results: Vec<(usize, u64)> = proposal
+            .result
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| !disqualified_candidates_indices.contains(idx))
+            .map(|(idx, &votes)| (idx, votes))
+            .collect();
+
         indexed_results.sort_by_key(|&(_, value)| std::cmp::Reverse(value));
 
         let mut winners = Vec::new();
         let last_out_idx = proposal.seats as usize;
-        let last_out_votes = if indexed_results.len() > last_out_idx {
-            indexed_results[last_out_idx].1
-        } else {
-            indexed_results[0].1 + 1 // max +1
-        };
+        let last_out_votes = indexed_results
+            .get(last_out_idx)
+            .map(|&(_, votes)| votes)
+            .unwrap_or(indexed_results[0].1 + 1);
+
         for (idx, votes) in indexed_results.into_iter().take(last_out_idx) {
-            // we need to filter out tie in the tail if it could exceed the seats
+            // Filter out tie in the tail if it could exceed the seats
             if proposal.min_candidate_support <= votes && last_out_votes < votes {
                 let candidate = proposal.candidates.get(idx).unwrap();
                 winners.push(candidate.clone());
@@ -114,5 +124,14 @@ impl Contract {
         }
 
         winners
+    }
+
+    /// Returns the list of disqualified candidates
+    pub fn disqualified_candidates(&self) -> Vec<AccountId> {
+        let mut res = Vec::new();
+        for c in self.disqualified_candidates.iter() {
+            res.push(c.clone());
+        }
+        res
     }
 }


### PR DESCRIPTION
+ add `disqualified_candidates` field 
+ add `disqualified_candidates` view method
+ add `admin_disqualify_candidates` method
+ rework `winners_by_proposal` to not include candidates listed in `disqualified_candidates`
+ remove slashing bond from `admin_revoke_vote` 
+ unit test
+ add migration 
+ migration integration test
TODO: populate the contract in the migration integration test with mocked data and check it does not break 