### PR TITLE
voting-body: use proposal.executed_at instead of approved_at

### DIFF
--- a/voting_body/src/lib.rs
+++ b/voting_body/src/lib.rs
@@ -157,7 +157,7 @@ impl Contract {
             supported: HashSet::new(),
             votes: HashMap::new(),
             start: now,
-            approved_at: None,
+            executed_at: None,
             proposal_storage: 0,
         };
         if active {
@@ -369,6 +369,7 @@ impl Contract {
 
         prop.refund_bond();
         prop.status = ProposalStatus::Executed;
+        prop.executed_at = Some(env::block_timestamp_ms());
         let mut out = PromiseOrValue::Value(ExecResponse::Executed);
         match &prop.kind {
             PropKind::Dismiss { dao, member } => {
@@ -505,6 +506,7 @@ impl Contract {
             PromiseResult::Failed => {
                 let mut prop = self.assert_proposal(prop_id);
                 prop.status = ProposalStatus::Failed;
+                prop.executed_at = None;
                 self.proposals.insert(&prop_id, &prop);
                 emit_executed(prop_id);
             }
@@ -942,6 +944,7 @@ mod unit_tests {
         ));
         p = ctr.get_proposal(id).unwrap();
         assert_eq!(p.proposal.status, ProposalStatus::Executed);
+        assert_eq!(p.proposal.executed_at, Some(ctx.block_timestamp / MSECOND));
 
         //
         // check spam transaction

--- a/voting_body/src/proposal.rs
+++ b/voting_body/src/proposal.rs
@@ -61,8 +61,9 @@ pub struct Proposal {
     pub votes: HashMap<AccountId, Vote>,
     /// start time (for voting period).
     pub start: u64,
-    /// Unix time in miliseconds when the proposal reached approval threshold. `None` if it is not approved.
-    pub approved_at: Option<u64>,
+    /// Unix time in miliseconds when the proposal was executed. `None` if it is not approved
+    /// or execution failed.
+    pub executed_at: Option<u64>,
     /// Proposal storage cost (excluding vote)
     pub proposal_storage: u128,
 }
@@ -122,7 +123,6 @@ impl Proposal {
 
         if self.approve > qualified * consent.threshold as u32 / 100 {
             self.status = ProposalStatus::Approved;
-            self.approved_at = Some(env::block_timestamp_ms()); // TODO: update to executed at
         } else if self.spam > self.reject
             && total_no >= qualified * (100 - consent.threshold) as u32 / 100
         {


### PR DESCRIPTION
We have to change the mechanism of setting approval date in Voting Body proposals. Proposals in VB are not executed automatically, so `proposal.approved_at` doesn't make sense. Instead we have `executed_at`.
Moreover, the status `Approved` is only temporal: it is shown only when a voting period is finished, proposal is approved but not executed yet. If the proposal is executed, then the status will be `Executed` or `Failed`